### PR TITLE
Adding UnPauseTrack for Arlo Baby to resume playlist w/o trackID

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -599,6 +599,9 @@ class Arlo(object):
     def PauseTrack(self, basestation):
         return self.Notify(basestation, {"action":"pause","resource":"audioPlayback/player"})
 
+    def UnPauseTrack(self, basestation):
+        return self.Notify(basestation, {"action":"play","resource":"audioPlayback/player"})
+   
     def SkipTrack(self, basestation):
         return self.Notify(basestation, {"action":"nextTrack","resource":"audioPlayback/player"})
 


### PR DESCRIPTION
Adds support for the "play" action as "UnPauseTrack" - useful in a scenario such as wanting to resume a playlist without specifying a TrackID. 

In conjunction with homebridge or other tools, can create a toggle for the sound, rather than a file playback trigger.